### PR TITLE
Scope for leaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ record:
     is_only_child?   Returns true if the record is the only child of its parent
     descendants      Scopes the model on direct and indirect children of the record
     descendant_ids   Returns a list of a descendant ids
+    leaves           Scopes the model on childless nodes from among the record's subtree
+    leaf_ids         Returns a list of leaf ids
+    leaf? is_leaf?   Returns true if the record is a leaf node (ie. childless), false otherwise
     subtree          Scopes the model on descendants and itself
     subtree_ids      Returns a list of all ids in the record's subtree
     depth            Return the depth of the node, root nodes are at depth 0
@@ -155,6 +158,7 @@ For convenience, a couple of named scopes are included at the class level:
     descendants_of(node)    Descendants of node, node can be either a record or an id
     subtree_of(node)        Subtree of node, node can be either a record or an id
     siblings_of(node)       Siblings of node, node can be either a record or an id
+    leaves_of(node)         Leaves of node, node can be either a record or an id
 
 Thanks to some convenient rails magic, it is even possible to create nodes
 through the children and siblings scopes:

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -44,6 +44,7 @@ module Ancestry
       scope :descendants_of, lambda { |object| where(descendant_conditions(object)) }
       scope :subtree_of, lambda { |object| where(subtree_conditions(object)) }
       scope :siblings_of, lambda { |object| where(sibling_conditions(object)) }
+      scope :leaves_of, lambda { |object| where(leaf_conditions(object)) }
       scope :ordered_by_ancestry, Proc.new { |order|
         if %w(mysql mysql2 sqlite sqlite3 postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
           reorder("coalesce(#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, '')", order)

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -266,6 +266,32 @@ module Ancestry
       ancestor_ids.include?(node.id)
     end
 
+    # Leaves
+
+    # def leaf_conditions
+    #   self.ancestry_base_class.leaf_conditions(self)
+    # end
+    def leaf_conditions
+      self.ancestry_base_class.leaf_conditions(self)
+    end
+
+    def leaves
+      self.ancestry_base_class.where leaf_conditions
+    end
+
+    def leaf_ids
+      self.leaves.pluck(self.ancestry_base_class.primary_key)
+    end
+
+    def is_leaf?
+      self.leaves.to_a == [self]
+    end
+    alias_method :leaf?, :is_leaf?
+
+    def leaf_of?(node)
+      node.leaf_ids.include?(self.id)
+    end
+
     # Subtree
 
     def subtree_conditions

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -50,6 +50,14 @@ module Ancestry
       t[ancestry_column].eq(node[ancestry_column])
     end
 
+    # idintifies leaves that belongs to the object (excluding itself)
+    def leaf_conditions(object)
+      t = arel_table
+      node = to_node(object)
+      all_ancestor_ids = self.ancestry_base_class.all.map(&:ancestor_ids).flatten.uniq
+      t[primary_key].not_in_all(all_ancestor_ids).and(descendant_conditions(object).or(t[primary_key].eq(node.id)))
+    end
+
     module InstanceMethods
       # Validates the ancestry, but can also be applied if validation is bypassed to determine if children should be affected
       def sane_ancestry?

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -22,6 +22,9 @@ class ScopesTest < ActiveSupport::TestCase
         # Assertions for siblings_of named scope
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node).to_a
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node.id).to_a
+        # Assertions for leaves_of named scope
+        assert_equal test_node.leaves.to_a, model.leaves_of(test_node).to_a
+        assert_equal test_node.leaves.to_a, model.leaves_of(test_node.id).to_a
         # Assertions for path_of named scope
         assert_equal test_node.path.to_a, model.path_of(test_node).to_a
         assert_equal test_node.path.to_a, model.path_of(test_node.id).to_a

--- a/test/concerns/tree_navigration_test.rb
+++ b/test/concerns/tree_navigration_test.rb
@@ -35,6 +35,14 @@ class TreeNavigationTest < ActiveSupport::TestCase
         assert_equal descendants.map(&:id), lvl0_node.descendant_ids
         assert_equal descendants, lvl0_node.descendants
         assert_equal [lvl0_node] + descendants, lvl0_node.subtree
+        # Leaves assertions
+        leaf_ids = model.all.map(&:id) - model.all.map(&:ancestor_ids).flatten.uniq
+        leaves = model.all.find_all do |node|
+          (leaf_ids.include? node.id) && (node.path_ids.include? lvl0_node.id)
+        end
+        assert_equal leaves.map(&:id), lvl0_node.leaf_ids
+        assert_equal leaves, lvl0_node.leaves
+        assert !lvl0_node.is_leaf?
 
         lvl0_children.each do |lvl1_node, lvl1_children|
           # Ancestors assertions
@@ -68,6 +76,14 @@ class TreeNavigationTest < ActiveSupport::TestCase
           assert_equal descendants.map(&:id), lvl1_node.descendant_ids
           assert_equal descendants, lvl1_node.descendants
           assert_equal [lvl1_node] + descendants, lvl1_node.subtree
+          # Leaves assertions
+          leaf_ids = model.all.map(&:id) - model.all.map(&:ancestor_ids).flatten.uniq
+          leaves = model.all.find_all do |node|
+            (leaf_ids.include? node.id) && (node.path_ids.include? lvl1_node.id)
+          end
+          assert_equal leaves.map(&:id), lvl1_node.leaf_ids
+          assert_equal leaves, lvl1_node.leaves
+          assert !lvl1_node.is_leaf?
 
           lvl1_children.each do |lvl2_node, lvl2_children|
             # Ancestors assertions
@@ -101,6 +117,14 @@ class TreeNavigationTest < ActiveSupport::TestCase
             assert_equal descendants.map(&:id), lvl2_node.descendant_ids
             assert_equal descendants, lvl2_node.descendants
             assert_equal [lvl2_node] + descendants, lvl2_node.subtree
+            # Leaves assertions
+            leaf_ids = model.all.map(&:id) - model.all.map(&:ancestor_ids).flatten.uniq
+            leaves = model.all.find_all do |node|
+              (leaf_ids.include? node.id) && (node.path_ids.include? lvl2_node.id)
+            end
+            assert_equal leaves.map(&:id), lvl2_node.leaf_ids
+            assert_equal leaves, lvl2_node.leaves
+            assert lvl2_node.is_leaf?
           end
         end
       end

--- a/test/concerns/tree_predicate_test.rb
+++ b/test/concerns/tree_predicate_test.rb
@@ -31,6 +31,11 @@ class TreePredicateTest < ActiveSupport::TestCase
         # Descendants assertions
         assert children.map { |n| !root.descendant_of?(n) }.all?
         assert children.map { |n| n.descendant_of?(root) }.all?
+        # Leaves assertions
+        assert !root.is_leaf?
+        assert children.map { |n| n.is_leaf? }.all?
+        assert children.map { |n| !root.leaf_of?(n) }.all?
+        assert children.map { |n| n.leaf_of?(root) }.all?
       end
     end
   end


### PR DESCRIPTION
### what it does

This PR is to adding scopes (with several related instance methods) for leaves.
Looks like there have been quite a few requests around this feature, so hoping it would give some solutions.

### thoughts..

As you can see the basic approach here consists of two steps:

1) collect all ancestor_ids from the model in order to later identify childless nodes (i.e. leaves)
2) using the ids above, search childless nodes that belongs to the subtree (incl. descendants and itself) of the given node. 

Another way is to use LEFT JOIN to its own table, eg.

```sql
  SELECT DISTINCT *
     FROM categories AS c
     LEFT OUTER JOIN categories AS c2
     ON ( CONCAT(c.ancestry, '/', c.id) = c2.ancestry) OR ( c.id = c2.ancestry)
    WHERE c2.id is null;
```

I actually implemented it with complex Arel, but that requires a slight hustle to handle database-dependent function `CONCAT` (`||` for sqlite3, or `+` in some cases).

The good point is it only creates single SQL query vs two in the earlier example - however I chose earlier approach as it seemed much cleaner codes imho.

Hope that makes sense! (and thanks as always for maintaining the awesome gem!)